### PR TITLE
Configure semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,18 @@
-language: node_js
-node_js:
-- "4"
-- "stable"
 sudo: false
+language: node_js
 cache:
   directories:
-  - node_modules
+    - node_modules
+notifications:
+  email: false
+node_js:
+  - '4'
+before_install:
+  - npm i -g npm@^2.0.0
+before_script:
+  - npm prune
+after_success:
+  - npm run semantic-release
+branches:
+  except:
+    - /^v\d+\.\d+\.\d+$/

--- a/README.md
+++ b/README.md
@@ -68,3 +68,52 @@ make coverage
 ```bash
 make benchmark
 ```
+
+## Committing
+This project uses [semantic release](https://github.com/semantic-release/semantic-release)
+to ensure version bumps follow semver so that projects using the config don't
+break unexpectedly.
+
+In order to automatically determine the type of version bump necessary, semantic
+release expects commit messages to be formatted following
+[conventional-changelog](https://github.com/bcoe/conventional-changelog-standard/blob/master/convention.md).
+```
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+`subject` and `body` are your familiar commit subject and body. `footer` is
+where you would include `BREAKING CHANGE` and `ISSUES FIXED` sections if
+applicable.
+
+`type` is one of:
+* `fix`: A bug fix **Causes a patch release (0.0.x)**
+* `feat`: A new feature **Causes a minor release (0.x.0)**
+* `docs`: Documentation only changes
+* `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+* `refactor`: A code change that neither fixes a bug nor adds a feature
+* `perf`: A code change that improves performance **May or may not cause a minor release. It's not clear.**
+* `test`: Adding missing tests or correcting existing tests
+* `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
+* `chore`: Other changes that don't modify src or test files
+* `revert`: Reverts a previous commit
+
+Use the [commitizen CLI](https://github.com/commitizen/cz-cli) to make commits
+formatted in this way:
+
+```bash
+npm install -g commitizen
+npm install
+```
+
+Now you're ready to make commits using `git cz`.
+
+## Breaking changes
+If you're committing a change that makes the linter more strict, or will
+otherwise require changes to existing code, ensure your commit specifies a
+breaking change.  In your commit body, prefix the changes with "BREAKING CHANGE: "
+This will cause a major version bump so downstream projects must choose to upgrade
+the config and will not break the build unexpectedly.

--- a/README.md
+++ b/README.md
@@ -112,8 +112,7 @@ npm install
 Now you're ready to make commits using `git cz`.
 
 ## Breaking changes
-If you're committing a change that makes the linter more strict, or will
-otherwise require changes to existing code, ensure your commit specifies a
-breaking change.  In your commit body, prefix the changes with "BREAKING CHANGE: "
+If you're committing a change that will require changes to existing code, ensure
+your commit specifies a breaking change.  In your commit body, prefix the changes with "BREAKING CHANGE: "
 This will cause a major version bump so downstream projects must choose to upgrade
 the config and will not break the build unexpectedly.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "scratch-parser",
-  "version": "1.0.0",
   "description": "Parser for Scratch projects",
   "author": "MIT Media Lab",
   "license": "BSD-3-Clause",
@@ -8,10 +7,11 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/LLK/scratch-parser.git"
+    "url": "https://github.com/LLK/scratch-parser.git"
   },
   "scripts": {
-    "test": "make test"
+    "test": "make test",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "dependencies": {
     "adm-zip": "0.4.7",
@@ -20,11 +20,18 @@
   },
   "devDependencies": {
     "benchmark": "^2.1.1",
+    "cz-conventional-changelog": "2.0.0",
     "eslint": "^3.5.0",
     "glob": "^7.0.6",
-    "tap": "^7.1.2"
+    "tap": "^7.1.2",
+    "semantic-release": "^6.3.2"
   },
   "engines": {
     "node": ">=4.0"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   }
 }


### PR DESCRIPTION
This adds and sets up the `semantic-release` package to use commits and travis to do automated semantic versioning and publishing to npm for scratch-parser. See semantic release's [setup guide](https://github.com/semantic-release/semantic-release#setup) for more info on this process.

It also adds a readme section about committing, and using `git cz` to handle formatting of commits in a way that is parseable and deployable by `semantic-release`.

This setup is based on the existing release setup in `eslint-config-scratch`.