### PR TITLE
build(unpack): Swap out 3rd party zip library

### DIFF
--- a/lib/unpack.js
+++ b/lib/unpack.js
@@ -1,4 +1,4 @@
-var Adm = require('adm-zip');
+var JSZip = require('jszip');
 
 /**
  * Transforms buffer into a UTF-8 string. If input is encoded in ZIP format,
@@ -33,7 +33,10 @@ module.exports = function (input, callback) {
 
     // Handle zip
     // @todo Handle error
-    var zip = new Adm(input);
-    var project = zip.readAsText('project.json', 'utf8');
-    callback(null, project);
+    JSZip.loadAsync(input).then(function (zip) {
+        zip.file('project.json').async('string')
+            .then(function (project) {
+                callback(null, project);
+            });
+    });
 };

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "dependencies": {
-    "adm-zip": "0.4.7",
     "ajv": "4.7.0",
-    "async": "2.0.1"
+    "async": "2.0.1",
+    "jszip": "3.1.5"
   },
   "devDependencies": {
     "benchmark": "^2.1.1",


### PR DESCRIPTION
Swapping out adm-zip dependency with jszip for use with the browser.