### PR TITLE
Allow unpacker to handle JSON strings.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var analyze = require('./lib/analyze');
  * Unpacks, parses, validates, and analyzes Scratch projects. If successful,
  * will return a valid Scratch project object with appended metadata.
  *
- * @param {Buffer} Input buffer
+ * @param {Buffer | string} Input buffer or string representing scratch project
  *
  * @return {Object}
  */

--- a/lib/unpack.js
+++ b/lib/unpack.js
@@ -1,17 +1,25 @@
 var JSZip = require('jszip');
 
 /**
- * Transforms buffer into a UTF-8 string. If input is encoded in ZIP format,
- * the input will be extracted and decoded.
+ * If input a buffer, transforms buffer into a UTF-8 string.
+ * If input is encoded in ZIP format, the input will be extracted and decoded.
+ * If input is a string, passes that string along to the given callback.
  *
- * @param {Buffer} Input
+ * @param {Buffer | string} Input
  *
  * @return {String}
  */
 module.exports = function (input, callback) {
+    if (typeof input === 'string') {
+        // Pass string to callback
+        return callback(null, input);
+    }
+
     // Validate input type
-    var typeError = 'Input must be a Buffer.';
-    if (!Buffer.isBuffer(input)) return callback(typeError);
+    var typeError = 'Input must be a Buffer or a string.';
+    if (!Buffer.isBuffer(input)) {
+        return callback(typeError);
+    }
 
     // Determine format
     // We don't use the file suffix as this is unreliable and mine-type

--- a/test/integration/empty.js
+++ b/test/integration/empty.js
@@ -29,3 +29,13 @@ test('json', function (t) {
         t.end();
     });
 });
+
+test('json string', function (t) {
+    parser(data.empty.json.toString('utf-8'), function (err, res) {
+        t.equal(err, null);
+        t.type(res, 'object');
+        t.type(res._meta, 'object');
+        t.type(res.info, 'object');
+        t.end();
+    });
+});

--- a/test/integration/example.js
+++ b/test/integration/example.js
@@ -29,3 +29,13 @@ test('json', function (t) {
         t.end();
     });
 });
+
+test('json string', function (t) {
+    parser(data.example.json.toString('utf-8'), function (err, res) {
+        t.equal(err, null);
+        t.type(res, 'object');
+        t.type(res._meta, 'object');
+        t.type(res.info, 'object');
+        t.end();
+    });
+});

--- a/test/integration/stress.js
+++ b/test/integration/stress.js
@@ -38,3 +38,16 @@ test('json', function (t) {
         });
     }
 });
+
+test('json string', function (t) {
+    var set = data.json;
+    t.plan(set.length * 4);
+    for (var i in data.json) {
+        parser(data.json[i].toString('utf-8'), function (err, res) {
+            t.equal(err, null);
+            t.type(res, 'object');
+            t.type(res._meta, 'object');
+            t.type(res.info, 'object');
+        });
+    }
+});

--- a/test/unit/unpack.js
+++ b/test/unit/unpack.js
@@ -51,6 +51,29 @@ test('json', function (t) {
     });
 });
 
+test('json utf-8 string', function (t) {
+    var buffer = new Buffer(fixtures.json);
+    unpack(buffer.toString('utf-8'), function (err, res) {
+        t.equal(err, null);
+        t.type(res, 'string');
+        t.doesNotThrow(function () {
+            JSON.parse(res);
+        });
+        t.end();
+    });
+});
+
+test('invalid string', function (t) {
+    unpack('this is not json', function (err, res) {
+        t.equal(err, null);
+        t.type(res, 'string');
+        t.throws(function () {
+            JSON.parse(res);
+        });
+        t.end();
+    });
+});
+
 test('undefined', function (t) {
     unpack(undefined, function (err, res) {
         t.type(err, 'string');


### PR DESCRIPTION
Unpack function can now be given a string as input and will pass it to along to the given callback. This is for handling project json files directly with scratch-parser's public function without causing a breaking change. This comes in handy when trying to validate projects loaded from scratch storage.

Added tests for the new functionality.