### PR TITLE
SB3 Schema/Validation and Refactor to support promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,25 +1,47 @@
-var async = require('async');
+var Promise = require('promise');
 
 var unpack = require('./lib/unpack');
 var parse = require('./lib/parse');
 var validate = require('./lib/validate');
 var analyze = require('./lib/analyze');
 
+
 /**
- * Unpacks, parses, validates, and analyzes Scratch projects. If successful,
- * will return a valid Scratch project object with appended metadata.
+ * Unpacks, parses, validates, and analyzes Scratch projects.
+ * If a callback is provided, passes a validated scratch object on success, or
+ * an error on failure.
+ * If a callback is not provided, returns a promise of a 2 element array of
+ * the validated project json and the entire unpacked zip (if zip was provided,
+ * or null if not provided)
+ * Promise rejects if the input could not be validated against the sb2 or sb3
+ * schemas.
  *
  * @param {Buffer | string} Input buffer or string representing scratch project
  *
  * @return {Object}
  */
 module.exports = function (input, callback) {
-    async.waterfall([
-        function (cb) {
-            unpack(input, cb);
-        },
-        parse,
-        validate,
-        analyze
-    ], callback);
+    var callbackWrapper = callback ?
+        (function (err, resArr) {
+            return callback(err, resArr ? resArr[0] : resArr);
+        }) :
+        callback;
+    return unpack(input)
+        .then(function (resultArr) {
+            var unpackedInput = resultArr[0];
+            var zip = resultArr[1];
+            return parse(unpackedInput)
+                .then(validate)
+                .then(function (validatedInput) {
+                    if (validatedInput.projectVersion === 2) {
+                        // Calling analyze only if project was SB2
+                        return analyze(validatedInput);
+                    }
+                    return Promise.resolve(validatedInput);
+                })
+                .then(function (fullyValidatedResult) {
+                    return Promise.resolve([fullyValidatedResult, zip]);
+                });
+        })
+        .nodeify(callbackWrapper);
 };

--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -1,3 +1,5 @@
+var Promise = require('promise');
+
 /**
  * Returns an array of items matching the specified attribute.
  *
@@ -182,7 +184,8 @@ function extensions (project) {
  *
  * @param {Object} Project
  *
- * @return {Object}
+ * @return {?Promise} Returns a promise or an object of the analyzed
+ * project object, depending on whether or not callback was provided.
  */
 module.exports = function (project, callback) {
     // Create metadata object
@@ -206,5 +209,5 @@ module.exports = function (project, callback) {
 
     // Bind metadata to project and return
     project._meta = meta;
-    callback(null, project);
+    return Promise.resolve(project).nodeify(callback);
 };

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,3 +1,5 @@
+var Promise = require('promise');
+
 /**
  * Converts string from unpack method into a project object. Note: this method
  * will be expanded greatly in the future in order to support the Scratch 1.4
@@ -6,12 +8,17 @@
  *
  * @param {String} Input
  *
- * @return {Object}
+ * @return {Promise} If callback function was provided, it gets called on
+ * the validated input, or an error object containing both sb2 and sb3 errors.
+ * If a callback function is not provided, this function returns
+ * a promise which resolves to the validated input or rejects to the error
+ * object described.
  */
 module.exports = function (input, callback) {
     try {
-        callback(null, JSON.parse(input));
+        var parsedInput = JSON.parse(input);
+        return Promise.resolve(parsedInput).nodeify(callback);
     } catch (e) {
-        return callback(e.toString());
+        return Promise.reject(e.toString()).nodeify(callback);
     }
 };

--- a/lib/sb2_schema.json
+++ b/lib/sb2_schema.json
@@ -1,5 +1,6 @@
 {
-    "id": "https://scratch.mit.edu",
+    "id": "https://scratch.mit.edu/sb2_schema.json",
+    "$schema": "http://json-schema.org/schema#",
     "description": "Scratch project schema",
     "type": "object",
     "properties": {

--- a/lib/sb3_schema.json
+++ b/lib/sb3_schema.json
@@ -203,10 +203,12 @@
                             "type": "string"
                         },
                         "warp": {
-                            "type": "boolean"
+                            "type": "string",
+                            "enum": ["true", "false"]
                         },
                         "hasnext": {
-                            "type": "boolean"
+                            "type": "string",
+                            "enum": ["true", "false"]
                         }
                     }
                 }
@@ -217,9 +219,35 @@
                 "topLevel"
             ]
         },
-        "target": {
+        "stage": {
             "type": "object",
+            "description": "Description of property (and/or property/value pairs) that are unique to the stage.",
             "properties": {
+                "name": {
+                    "type": "string",
+                    "enum": ["Stage"]
+                },
+                "isStage": {
+                    "type": "boolean",
+                    "enum": [true]
+                },
+            }
+        },
+        "sprite": {
+            "type": "object",
+            "description": "Description of property (and/or property/value pairs) for sprites.",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "not": {"enum": ["Stage", "stage"]}
+                },
+                "isStage": {
+                    "type": "boolean",
+                    "enum": [false]
+                },
+                "visible": {
+                    "type": "boolean",
+                },
                 "x": {
                     "type": "number"
                 },
@@ -239,14 +267,19 @@
                     "type": "string",
                     "enum": ["all around", "don't rotate", "left-right"]
                 },
+            },
+            "required": [
+                "name",
+                "isStage"
+            ]
+        },
+        "target": {
+            "type": "object",
+            "description" : "Properties common to both Scratch 3.0 Stage and Sprite",
+            "properties": {
                 "currentCostume": {
                     "type": "integer",
                     "minimum": 0
-                },
-                "costume": {"$ref": "#/definitions/costume"},
-                "costumeCount": {
-                    "type": "integer",
-                    "minimum": 1
                 },
                 "blocks": {
                     "type": "object",
@@ -278,46 +311,9 @@
                 "variables",
                 "costumes",
                 "sounds",
-                "blocks",
-                "rotationStyle",
-                "draggable"
+                "blocks"
             ]
         },
-        "stage": {
-            "type": "object",
-            "description": "Description of property (and/or property/value pairs) that are unique to the stage.",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "enum": ["Stage"]
-                },
-                "isStage": {
-                    "type": "boolean",
-                    "enum": [true]
-                },
-                "visible": {
-                    "type": "boolean",
-                    "enum": [true]
-                }
-            }
-        },
-        "sprite": {
-            "type": "object",
-            "description": "Description of property (and/or property/value pairs) for sprites.",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "not": {"enum": ["Stage", "stage"]}
-                },
-                "isStage": {
-                    "type": "boolean",
-                    "enum": [false]
-                },
-                "visible": {
-                    "type": "boolean",
-                }
-            }
-        }
     },
     "type": "object",
     "properties": {

--- a/lib/sb3_schema.json
+++ b/lib/sb3_schema.json
@@ -1,0 +1,366 @@
+{
+    "id": "https://scratch.mit.edu",
+    "description": "Scratch 3.0 Project Schema",
+    "definitions": {
+        "optionalString": {
+            "oneOf": [
+                {"type": "string"},
+                {"type": "null"}
+            ]
+        },
+        "assetId": {
+            "type": "string",
+            "pattern": "^[a-f0-9]+$"
+        },
+        "costume": {
+            "type": "object",
+            "properties": {
+                "assetId": { "$ref": "#/definitions/assetId"},
+                "bitmapResolution": {
+                    "type": "integer"
+                },
+                "dataFormat": {
+                    "type": "string",
+                    "enum": ["png", "PNG", "svg", "SVG", "jpeg", "JPEG", "jpg", "JPG", "bmp", "BMP"]
+                },
+                "name": {
+                    "type": "string"
+                },
+                "rotationCenterX": {
+                    "type": "number"
+                },
+                "rotationCenterY": {
+                    "type": "number"
+                },
+                "skinId": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "assetId",
+                "dataFormat",
+                "name",
+                "rotationCenterX",
+                "rotationCenterY"
+            ]
+        },
+        "sound": {
+            "type": "object",
+            "properties": {
+                "assetId": { "$ref": "#/definitions/assetId"},
+                "dataFormat": {
+                    "type": "string",
+                    "enum": ["wav", "WAV", "wave", "WAVE", "mp3", "MP3"]
+                },
+                "format": {
+                    "type": "string",
+                    "enum": ["", "adpcm"]
+                },
+                "md5": {
+                    "type": "string",
+                    "pattern": "^[a-f0-9]+.[a-z]+$"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "rate": {
+                    "type": "integer"
+                },
+                "sampleCount": {
+                    "type": "integer"
+                },
+                "soundID": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "assetId",
+                "dataFormat",
+                "format",
+                "name",
+                "rate",
+                "sampleCount"
+            ]
+        },
+        "scalar_variable": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": ["", "scalar"],
+                },
+                "value": {
+                    "oneOf": [
+                        {"type": "string"},
+                        {"type": "number"}
+                    ]
+                }
+            }
+        },
+        "list": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": ["list"]
+                },
+                "value": {
+                    "type": "array"
+                }
+            }
+        },
+        "broadcast_message": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": ["broadcast_msg"]
+                },
+                "value": {
+                    "type": "string",
+                    "not": {"enum": [""]}
+                }
+            }
+        },
+        "block": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "opcode": {
+                    "type": "string"
+                },
+                "inputs": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "block": {
+                                "type": "string"
+                            },
+                            "shadow": {"$ref":"#/definitions/optionalString"},
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "fields": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "next": {"$ref":"#/definitions/optionalString"},
+                "topLevel": {
+                    "type": "boolean"
+                },
+                "parent": {"$ref":"#/definitions/optionalString"},
+                "shadow": {
+                    "type": "boolean"
+                },
+                "x": {
+                    "type": "number"
+                },
+                "y": {
+                    "type": "number"
+                },
+                "mutation": {
+                    "type": "object",
+                    "properties": {
+                        "tagName": {
+                            "type": "string",
+                            "enum": ["mutation"]
+                        },
+                        "children": {
+                            "type": "array"
+                        },
+                        "proccode": {
+                            "type": "string"
+                        },
+                        "argumentids": {
+                            "type": "string"
+                        },
+                        "warp": {
+                            "type": "boolean"
+                        },
+                        "hasnext": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "id",
+                "opcode",
+                "topLevel"
+            ]
+        },
+        "target": {
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number"
+                },
+                "y": {
+                    "type": "number"
+                },
+                "size": {
+                    "type": "number"
+                },
+                "direction": {
+                    "type": "number"
+                },
+                "draggable": {
+                    "type": "boolean"
+                },
+                "rotationStyle": {
+                    "type": "string",
+                    "enum": ["all around", "don't rotate", "left-right"]
+                },
+                "currentCostume": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "costume": {"$ref": "#/definitions/costume"},
+                "costumeCount": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "blocks": {
+                    "type": "object",
+                    "additionalProperties": {"$ref":"#/definitions/block"}
+                },
+                "variables": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {"$ref":"#/definitions/scalar_variable"},
+                            {"$ref":"#/definitions/list"},
+                            {"$ref":"#/definitions/broadcast_message"}
+                        ]
+                    }
+                },
+                "costumes": {
+                    "type": "array",
+                    "items": {"$ref":"#/definitions/costume"},
+                    "minItems": 1,
+                    "uniqueItems": true
+                },
+                "sounds":{
+                    "type": "array",
+                    "items": {"$ref":"#/definitions/sound"},
+                    "uniqueItems": true
+                }
+            },
+            "required": [
+                "variables",
+                "costumes",
+                "sounds",
+                "blocks",
+                "rotationStyle",
+                "draggable"
+            ]
+        },
+        "stage": {
+            "type": "object",
+            "description": "Description of property (and/or property/value pairs) that are unique to the stage.",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "enum": ["Stage"]
+                },
+                "isStage": {
+                    "type": "boolean",
+                    "enum": [true]
+                },
+                "visible": {
+                    "type": "boolean",
+                    "enum": [true]
+                }
+            }
+        },
+        "sprite": {
+            "type": "object",
+            "description": "Description of property (and/or property/value pairs) for sprites.",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "not": {"enum": ["Stage", "stage"]}
+                },
+                "isStage": {
+                    "type": "boolean",
+                    "enum": [false]
+                },
+                "visible": {
+                    "type": "boolean",
+                }
+            }
+        }
+    },
+    "type": "object",
+    "properties": {
+        "meta": {
+            "type": "object",
+            "properties": {
+                "semver": {
+                    "type": "string",
+                    "pattern": "^(3.[0-9]+.[0-9]+)$"
+                },
+                "vm": {
+                    "type": "string",
+                    "pattern": "^([0-9]+.[0-9]+.[0-9]+)$"
+                },
+                "agent": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "semver"
+            ]
+        },
+
+        "targets": {
+            "type": "array",
+            "items": [
+                {
+                    "allOf": [
+                        {"$ref": "#/definitions/stage" },
+                        {"$ref": "#/definitions/target"}
+                    ]
+                }
+            ],
+            "additionalItems": {
+                "allOf": [
+                    {"$ref": "#/definitions/sprite"},
+                    {"$ref": "#/definitions/target"}
+                ]
+            }
+        }
+    },
+    "required": [
+        "meta",
+        "targets"
+    ]
+}

--- a/lib/sb3_schema.json
+++ b/lib/sb3_schema.json
@@ -10,7 +10,7 @@
         },
         "assetId": {
             "type": "string",
-            "pattern": "^[a-f0-9]+$"
+            "pattern": "^[a-f0-9]{32}$"
         },
         "costume": {
             "type": "object",
@@ -58,7 +58,7 @@
                 },
                 "md5": {
                     "type": "string",
-                    "pattern": "^[a-f0-9]+.[a-z]+$"
+                    "pattern": "^[a-f0-9]{32}.[a-z]+$"
                 },
                 "name": {
                     "type": "string"

--- a/lib/sb3_schema.json
+++ b/lib/sb3_schema.json
@@ -1,5 +1,6 @@
 {
-    "id": "https://scratch.mit.edu",
+    "id": "https://scratch.mit.edu/sb3_schema.json",
+    "$schema": "http://json-schema.org/schema#",
     "description": "Scratch 3.0 Project Schema",
     "definitions": {
         "optionalString": {
@@ -90,7 +91,7 @@
                 },
                 "type": {
                     "type": "string",
-                    "enum": ["", "scalar"],
+                    "enum": ["", "scalar"]
                 },
                 "value": {
                     "oneOf": [
@@ -230,7 +231,7 @@
                 "isStage": {
                     "type": "boolean",
                     "enum": [true]
-                },
+                }
             }
         },
         "sprite": {
@@ -246,7 +247,7 @@
                     "enum": [false]
                 },
                 "visible": {
-                    "type": "boolean",
+                    "type": "boolean"
                 },
                 "x": {
                     "type": "number"
@@ -266,7 +267,7 @@
                 "rotationStyle": {
                     "type": "string",
                     "enum": ["all around", "don't rotate", "left-right"]
-                },
+                }
             },
             "required": [
                 "name",
@@ -313,7 +314,7 @@
                 "sounds",
                 "blocks"
             ]
-        },
+        }
     },
     "type": "object",
     "properties": {

--- a/lib/unpack.js
+++ b/lib/unpack.js
@@ -1,24 +1,44 @@
 var JSZip = require('jszip');
+var Promise = require('promise');
 
 /**
- * If input a buffer, transforms buffer into a UTF-8 string.
+ * If input is a buffer, transforms buffer into a UTF-8 string.
  * If input is encoded in ZIP format, the input will be extracted and decoded.
- * If input is a string, passes that string along to the given callback.
+ * If input is a string, resolves promise with that string.
+ * This function returns a promise, but if a callback is provided,
+ * this function will pass the relevant info to the callback as if un-promised.
+ * The zip is explicitly not provided to the callback, but is resolved in the
+ * promise. This is to support functionality needed by scratch-vm, but to
+ * avoid major breaking changes with dependencies of this library.
  *
  * @param {Buffer | string} Input
  *
- * @return {String}
+ * @return {?Promise} A promise of the unpacked project as a 2-element array of
+ * the project json and the entire unpacked zip (if zip was provided,
+ * or null if not provided)
+ * Promise rejects upon any errors encountered in the unpacking process
+ * (including if provided a .sb file).
  */
 module.exports = function (input, callback) {
+    var callbackWrapper = callback ?
+        (function (err, resArr) {
+            return callback(err, resArr ? resArr[0] : resArr);
+        }) :
+        callback;
+
     if (typeof input === 'string') {
-        // Pass string to callback
-        return callback(null, input);
+        return Promise.resolve([input, null])
+            .nodeify(callbackWrapper);
     }
 
     // Validate input type
-    var typeError = 'Input must be a Buffer or a string.';
     if (!Buffer.isBuffer(input)) {
-        return callback(typeError);
+        try {
+            input = new Buffer(input);
+        } catch (e) {
+            return Promise.reject('Input must be a Buffer or a string.')
+                .nodeify(callbackWrapper);
+        }
     }
 
     // Determine format
@@ -34,17 +54,25 @@ module.exports = function (input, callback) {
     if (signature.indexOf('80 75') === 0) isZip = true;
 
     // If not legacy or zip, convert buffer to UTF-8 string and return
-    if (!isZip && !isLegacy) return callback(null, input.toString('utf-8'));
+    if (!isZip && !isLegacy) {
+        return Promise.resolve([input.toString('utf-8'), null])
+            .nodeify(callbackWrapper);
+    }
 
-    // Return error if legacy encoding detected
-    if (isLegacy) return callback('Parser only supports Scratch 2.X');
+    // Reject if legacy encoding detected
+    if (isLegacy) {
+        return Promise.reject('Parser only supports Scratch 2.X and above')
+            .nodeify(callbackWrapper);
+    }
 
     // Handle zip
-    // @todo Handle error
-    JSZip.loadAsync(input).then(function (zip) {
-        zip.file('project.json').async('string')
+    // Need this extra Promise.resolve here so that the correct kind of promise
+    // is returned
+    return Promise.resolve(JSZip.loadAsync(input).then(function (zip) {
+        return zip.file('project.json').async('string')
             .then(function (project) {
-                callback(null, project);
+                return Promise.resolve([project, zip])
+                    .nodeify(callbackWrapper);
             });
-    });
+    }));
 };

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,10 +1,46 @@
 var ajv = require('ajv')();
-var schema = require('./schema.json');
+var Promise = require('promise');
 
+var sb2schema = require('./sb2_schema.json');
+var sb3schema = require('./sb3_schema.json');
+
+/**
+ * Validates provided input as a Scratch project (either in 2.0 or 3.0 format).
+ * This function returns a Promise (if a callback function is not specified)
+ * or the result of running the provided promise on the input if it is
+ * determined to be valid, or an error object containing
+ * both sb2 and sb3 errors.
+ *
+ * @param {Buffer | string} Input
+ *
+ * @return {?Promise} If callback function was provided, it gets called on
+ * the validated input, or an error object containing both sb2 and sb3 errors.
+ * If a callback function is not provided, this function returns
+ * a promise of which resolves to the validated input or rejects to the error
+ * object described.
+ */
 module.exports = function (input, callback) {
-    var validate = ajv.compile(schema);
-    var valid = validate(input);
+    var validateSb2 = ajv.compile(sb2schema);
+    var validateSb3 = ajv.compile(sb3schema);
 
-    if (!valid) return callback(validate.errors);
-    callback(null, input);
+    var isValidSb2 = validateSb2(input);
+
+    if (isValidSb2) {
+        input.projectVersion = 2;
+        return Promise.resolve(input).nodeify(callback);
+    }
+
+    var isValidSb3 = validateSb3(input);
+    if (isValidSb3) {
+        input.projectVersion = 3;
+        return Promise.resolve(input).nodeify(callback);
+    }
+
+    var validationErrors = {
+        validationError: 'Could not parse as a valid SB2 or SB3 project.',
+        sb2Errors: validateSb2.errors,
+        sb3Errors: validateSb3.errors
+    };
+
+    return Promise.reject(validationErrors).nodeify(callback);
 };

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "ajv": "4.7.0",
     "async": "2.0.1",
-    "jszip": "3.1.5"
+    "jszip": "3.1.5",
+    "promise": "8.0.1"
   },
   "devDependencies": {
     "benchmark": "^2.1.1",

--- a/test/unit/parser.js
+++ b/test/unit/parser.js
@@ -9,9 +9,15 @@ test('spec', function (t) {
 
 test('valid', function (t) {
     for (var i = 0; i < data.json.length; i++) {
-        parse(data.json[i].toString(), function (err, res) {
-            t.equal(err, null);
-            t.type(res, 'object');
+        var currData = data.json[i];
+        var testString = 'valid subtest ' + i;
+        test(testString, function(subTest) {
+            parse(currData.toString(),
+                function (err, res) {
+                    subTest.equal(err, null);
+                    subTest.type(res, 'object');
+                    subTest.end();
+                });
         });
     }
     t.end();

--- a/test/unit/schema.js
+++ b/test/unit/schema.js
@@ -1,7 +1,7 @@
 var ajv = require('ajv')();
 var test = require('tap').test;
 var meta = require('../fixtures/meta.json');
-var schema = require('../../lib/schema.json');
+var schema = require('../../lib/sb2_schema.json');
 
 test('spec', function (t) {
     t.type(schema, 'object');

--- a/test/unit/validate.js
+++ b/test/unit/validate.js
@@ -17,15 +17,18 @@ test('valid', function (t) {
 
 test('invalid', function (t) {
     validate({foo:1}, function (err, res) {
-        t.equal(Array.isArray(err), true);
+        t.type(err, 'object');
+        t.type(err.validationError, 'string');
+        var sb2Errs = err.sb2Errors;
+        t.equal(Array.isArray(sb2Errs), true);
         t.equal(res, undefined);
-        t.type(err[0], 'object');
-        t.type(err[0].keyword, 'string');
-        t.type(err[0].dataPath, 'string');
-        t.type(err[0].schemaPath, 'string');
-        t.type(err[0].message, 'string');
-        t.type(err[0].params, 'object');
-        t.type(err[0].params.missingProperty, 'string');
+        t.type(sb2Errs[0], 'object');
+        t.type(sb2Errs[0].keyword, 'string');
+        t.type(sb2Errs[0].dataPath, 'string');
+        t.type(sb2Errs[0].schemaPath, 'string');
+        t.type(sb2Errs[0].message, 'string');
+        t.type(sb2Errs[0].params, 'object');
+        t.type(sb2Errs[0].params.missingProperty, 'string');
         t.end();
     });
 });


### PR DESCRIPTION
This pull request is a major deviation from the history of this library, but aims to continue supporting this library's dependencies.

### Proposed Changes
- Adding an sb3 schema (this is a first draft of the schema, which is still a WIP, feedback is welcome)
- Modifying the validator to validate against the sb2 and sb3 schemas to determine if the given 
input is valid against either of them. ***Note:*** since the validator is now validating against two different schemas, the 'error' returned by the validate function is now an object which includes both sb2 and sb3 errors if the input failed to validate against both specifications.
- A major refactor of this library to use promises (as necessitated by the use of the JSZip library). Though this is a major refactor, this library should still accommodate the use NodeJS style callbacks thanks to [the promise library's `.nodeify` construct](https://www.npmjs.com/package/promise#promisenodeifycallback).

### Test Coverage
The existing tests have been modified to accommodate these changes as necessary. Additional tests to be added for sb3 validation and for testing the new promise functionality. Both of these have been manually tested through scratch-vm and scratch-gui.

### Additional Notes
This PR is related to the following PRs, and should be merged before either of them. The changes in these other PRs depend on the changes proposed by this PR.