### PR TITLE
SB3 Schema fixes

### DIFF
--- a/lib/sb3_schema.json
+++ b/lib/sb3_schema.json
@@ -9,6 +9,13 @@
                 {"type": "null"}
             ]
         },
+        "boolOrBoolString": {
+            "oneOf": [
+                {"type": "string",
+                 "enum": ["true", "false"]},
+                {"type": "boolean"}
+            ]
+        },
         "assetId": {
             "type": "string",
             "pattern": "^[a-fA-F0-9]{32}$"
@@ -145,9 +152,7 @@
                             "name": {
                                 "type": "string"
                             },
-                            "block": {
-                                "type": "string"
-                            },
+                            "block": {"$ref":"#/definitions/optionalString"},
                             "shadow": {"$ref":"#/definitions/optionalString"},
                             "value": {
                                 "oneOf": [
@@ -205,14 +210,8 @@
                         "argumentids": {
                             "type": "string"
                         },
-                        "warp": {
-                            "type": "string",
-                            "enum": ["true", "false"]
-                        },
-                        "hasnext": {
-                            "type": "string",
-                            "enum": ["true", "false"]
-                        }
+                        "warp": {"$ref":"#/definitions/boolOrBoolString"},
+                        "hasnext": {"$ref":"#/definitions/boolOrBoolString"}
                     }
                 }
             },

--- a/lib/sb3_schema.json
+++ b/lib/sb3_schema.json
@@ -76,9 +76,7 @@
                 "assetId",
                 "dataFormat",
                 "format",
-                "name",
-                "rate",
-                "sampleCount"
+                "name"
             ]
         },
         "scalar_variable": {


### PR DESCRIPTION
Some fixes for the sb3 schema including: 
- support for recorded sounds (by removing requirement of 'rate' and 'sampleCount' properties). They aren't used directly, and should be extracted from the wav files instead of from the project json.
- support for sb2 -> sb3 conversion (there were some problems encountered with sb2 -> sb3 conversion in the smoke test with 2.0 custom procedures and another issue with the substack of a c-block being empty (null).

Resolves https://github.com/LLK/scratch-vm/issues/997