### PR TITLE
Block serialization compression

### DIFF
--- a/lib/sb3_schema.json
+++ b/lib/sb3_schema.json
@@ -368,7 +368,7 @@
                     "additionalProperties": {
                         "oneOf": [
                             {"$ref":"#/definitions/block"},
-                            {"$ref":"#/definitions/inputPrimitive"}
+                            {"$ref":"#/definitions/topLevelPrimitive"}
                         ]
                     }
                 },

--- a/lib/sb3_schema.json
+++ b/lib/sb3_schema.json
@@ -22,6 +22,12 @@
                 {"type": "number"}
             ]
         },
+        "scalarVal": {
+            "oneOf": [
+                {"$ref":"#/definitions/stringOrNumber"},
+                {"type": "boolean"}
+            ]
+        },
         "assetId": {
             "type": "string",
             "pattern": "^[a-fA-F0-9]{32}$"
@@ -96,9 +102,10 @@
             "type": "array",
             "items": [
                 {"type": "string"},
-                {"$ref":"#/definitions/stringOrNumber"}
+                {"$ref":"#/definitions/scalarVal"}
             ],
-            "additionalItems": {"type": "boolean", "enum": [true]}
+            "additionalItems": {"type": "boolean", "enum": [true], "description": "Whether this is a cloud variable"},
+            "maxItems": 3
         },
         "list": {
             "type": "array",
@@ -106,7 +113,7 @@
                 {"type":"string"},
                 {
                     "type": "array",
-                    "items": {"$ref":"#/definitions/stringOrNumber"}
+                    "items": {"$ref":"#/definitions/scalarVal"}
                 }
             ],
             "additionalItems": false
@@ -121,10 +128,22 @@
             "items": [
                 {
                     "type": "number",
-                    "enum": [4,9,0]
+                    "enum": [4,5,6,7,8]
+                },
+                {"$ref":"#/definitions/stringOrNumber"}
+            ],
+            "additionalItems": false
+        },
+        "color_primitive": {
+            "type": "array",
+            "items": [
+                {
+                    "type": "number",
+                    "enum": [9]
                 },
                 {
-                    "type": "number"
+                    "type": "string",
+                    "pattern": "^#[a-fA-F0-9]{6}$"
                 }
             ],
             "additionalItems": false
@@ -134,7 +153,7 @@
             "items": [
                 {
                     "type": "number",
-                    "enum": [5]
+                    "enum": [10]
                 },
                 {"$ref":"#/definitions/stringOrNumber"}
             ],
@@ -145,14 +164,10 @@
             "items": [
                 {
                     "type": "number",
-                    "enum": [6]
+                    "enum": [11]
                 },
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "string"
-                }
+                {"type": "string", "description": "broadcast message"},
+                {"type": "string", "description": "broadcast message id"}
             ],
             "additionalItems": false
         },
@@ -161,31 +176,32 @@
             "items": [
                 {
                     "type": "number",
-                    "enum": [7]
+                    "enum": [12]
                 },
-                {"$ref":"#/definitions/stringOrNumber"},
-                {"type": "string"}
+                {"type": "string", "description": "variable name"},
+                {"type": "string", "description": "variable id"}
             ],
             "additionalItems": {
                 "type": "number"
-            }
+            },
+            "minItems": 3,
+            "maxItems": 5
         },
         "list_primitive": {
             "type": "array",
             "items": [
                 {
                     "type": "number",
-                    "enum": [8]
+                    "enum": [13]
                 },
-                {
-                    "type": "array",
-                    "items": {"$ref":"#/definitions/stringOrNumber"}
-                },
-                {"type": "string"}
+                {"type": "string", "description": "list name"},
+                {"type": "string", "description": "list id"}
             ],
             "additionalItems": {
                 "type": "number"
-            }
+            },
+            "minItems": 3,
+            "maxItems": 5
         },
         "topLevelPrimitive": {
             "oneOf": [
@@ -196,6 +212,7 @@
         "inputPrimitive": {
             "oneOf": [
                 {"$ref":"#/definitions/num_primitive"},
+                {"$ref":"#/definitions/color_primitive"},
                 {"$ref":"#/definitions/text_primitive"},
                 {"$ref":"#/definitions/broadcast_primitive"},
                 {"$ref":"#/definitions/variable_primitive"},
@@ -335,7 +352,7 @@
                     "additionalProperties": {
                         "oneOf": [
                             {"$ref":"#/definitions/block"},
-                            {"$ref":"#/definitions/topLevelPrimitive"}
+                            {"$ref":"#/definitions/inputPrimitive"}
                         ]
                     }
                 },

--- a/lib/sb3_schema.json
+++ b/lib/sb3_schema.json
@@ -129,7 +129,6 @@
                 {
                     "type": "number",
                     "enum": [4,5,6,7,8]
-
                 },
                 {"$ref":"#/definitions/stringOrNumber"}
             ],

--- a/lib/sb3_schema.json
+++ b/lib/sb3_schema.json
@@ -16,6 +16,12 @@
                 {"type": "boolean"}
             ]
         },
+        "stringOrNumber": {
+            "oneOf": [
+                {"type": "string"},
+                {"type": "number"}
+            ]
+        },
         "assetId": {
             "type": "string",
             "pattern": "^[a-fA-F0-9]{32}$"
@@ -29,7 +35,7 @@
                 },
                 "dataFormat": {
                     "type": "string",
-                    "enum": ["png", "PNG", "svg", "SVG", "jpeg", "JPEG", "jpg", "JPG", "bmp", "BMP"]
+                    "enum": ["png", "PNG", "svg", "SVG", "jpeg", "JPEG", "jpg", "JPG", "bmp", "BMP", "gif", "GIF"]
                 },
                 "md5ext": {
                     "type": "string",
@@ -87,98 +93,141 @@
             ]
         },
         "scalar_variable": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string",
-                    "enum": ["", "scalar"]
-                },
-                "value": {
-                    "oneOf": [
-                        {"type": "string"},
-                        {"type": "number"}
-                    ]
-                }
-            }
+            "type": "array",
+            "items": [
+                {"type": "string"},
+                {"$ref":"#/definitions/stringOrNumber"}
+            ],
+            "additionalItems": {"type": "boolean", "enum": [true]}
         },
         "list": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string",
-                    "enum": ["list"]
-                },
-                "value": {
-                    "type": "array"
+            "type": "array",
+            "items": [
+                {"type":"string"},
+                {
+                    "type": "array",
+                    "items": {"$ref":"#/definitions/stringOrNumber"}
                 }
-            }
+            ],
+            "additionalItems": false
         },
         "broadcast_message": {
-            "type": "object",
-            "properties": {
-                "name": {
+            "type": "array",
+            "items": {"type": "string"},
+            "additionalItems": false
+        },
+        "num_primitive": {
+            "type": "array",
+            "items": [
+                {
+                    "type": "number",
+                    "enum": [4,9,0]
+                },
+                {
+                    "type": "number"
+                }
+            ],
+            "additionalItems": false
+        },
+        "text_primitive": {
+            "type": "array",
+            "items": [
+                {
+                    "type": "number",
+                    "enum": [5]
+                },
+                {"$ref":"#/definitions/stringOrNumber"}
+            ],
+            "additionalItems": false
+        },
+        "broadcast_primitive": {
+            "type": "array",
+            "items": [
+                {
+                    "type": "number",
+                    "enum": [6]
+                },
+                {
                     "type": "string"
                 },
-                "type": {
-                    "type": "string",
-                    "enum": ["broadcast_msg"]
-                },
-                "value": {
-                    "type": "string",
-                    "not": {"enum": [""]}
+                {
+                    "type": "string"
                 }
+            ],
+            "additionalItems": false
+        },
+        "variable_primitive": {
+            "type": "array",
+            "items": [
+                {
+                    "type": "number",
+                    "enum": [7]
+                },
+                {"$ref":"#/definitions/stringOrNumber"},
+                {"type": "string"}
+            ],
+            "additionalItems": {
+                "type": "number"
             }
+        },
+        "list_primitive": {
+            "type": "array",
+            "items": [
+                {
+                    "type": "number",
+                    "enum": [8]
+                },
+                {
+                    "type": "array",
+                    "items": {"$ref":"#/definitions/stringOrNumber"}
+                },
+                {"type": "string"}
+            ],
+            "additionalItems": {
+                "type": "number"
+            }
+        },
+        "topLevelPrimitive": {
+            "oneOf": [
+                {"$ref":"#/definitions/variable_primitive"},
+                {"$ref":"#/definitions/list_primitive"}
+            ]
+        },
+        "inputPrimitive": {
+            "oneOf": [
+                {"$ref":"#/definitions/num_primitive"},
+                {"$ref":"#/definitions/text_primitive"},
+                {"$ref":"#/definitions/broadcast_primitive"},
+                {"$ref":"#/definitions/variable_primitive"},
+                {"$ref":"#/definitions/list_primitive"}
+            ]
         },
         "block": {
             "type": "object",
             "properties": {
-                "id": {
-                    "type": "string"
-                },
                 "opcode": {
                     "type": "string"
                 },
                 "inputs": {
                     "type": "object",
                     "additionalProperties": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "block": {"$ref":"#/definitions/optionalString"},
-                            "shadow": {"$ref":"#/definitions/optionalString"},
-                            "value": {
-                                "oneOf": [
-                                    {"type": "string"},
-                                    {"type": "number"}
-                                ]
+                        "type": "array",
+                        "items": [
+                            {
+                                "type":"number",
+                                "enum":[1,2,3]
                             }
+                        ],
+                        "additionalItems": {
+                            "oneOf": [
+                                {"$ref":"#/definitions/optionalString"},
+                                {"$ref":"#/definitions/inputPrimitive"}
+                            ]
                         }
                     }
                 },
                 "fields": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "oneOf": [
-                                    {"type": "string"},
-                                    {"type": "number"}
-                                ]
-                            }
-                        }
-                    }
+                    "type": "object"
                 },
                 "next": {"$ref":"#/definitions/optionalString"},
                 "topLevel": {
@@ -216,7 +265,6 @@
                 }
             },
             "required": [
-                "id",
                 "opcode"
             ]
         },
@@ -284,17 +332,21 @@
                 },
                 "blocks": {
                     "type": "object",
-                    "additionalProperties": {"$ref":"#/definitions/block"}
-                },
-                "variables": {
-                    "type": "object",
                     "additionalProperties": {
                         "oneOf": [
-                            {"$ref":"#/definitions/scalar_variable"},
-                            {"$ref":"#/definitions/list"},
-                            {"$ref":"#/definitions/broadcast_message"}
+                            {"$ref":"#/definitions/block"},
+                            {"$ref":"#/definitions/topLevelPrimitive"}
                         ]
                     }
+                },
+                "variables": {
+                    "type": "object"
+                },
+                "lists": {
+                    "type": "object"
+                },
+                "broadcasts": {
+                    "type": "object"
                 },
                 "costumes": {
                     "type": "array",

--- a/lib/sb3_schema.json
+++ b/lib/sb3_schema.json
@@ -41,7 +41,7 @@
                 },
                 "dataFormat": {
                     "type": "string",
-                    "enum": ["png", "PNG", "svg", "SVG", "jpeg", "JPEG", "jpg", "JPG", "bmp", "BMP", "gif", "GIF"]
+                    "enum": ["png", "svg", "jpeg", "jpg", "bmp", "gif"]
                 },
                 "md5ext": {
                     "type": "string",
@@ -71,7 +71,7 @@
                 "assetId": { "$ref": "#/definitions/assetId"},
                 "dataFormat": {
                     "type": "string",
-                    "enum": ["wav", "WAV", "wave", "WAVE", "mp3", "MP3"]
+                    "enum": ["wav", "wave", "mp3"]
                 },
                 "format": {
                     "type": "string",
@@ -129,6 +129,7 @@
                 {
                     "type": "number",
                     "enum": [4,5,6,7,8]
+
                 },
                 {"$ref":"#/definitions/stringOrNumber"}
             ],
@@ -232,7 +233,8 @@
                         "items": [
                             {
                                 "type":"number",
-                                "enum":[1,2,3]
+                                "enum":[1,2,3],
+                                "description": "1 = unobscured shadow, 2 = no shadow, 3 = obscured shadow"
                             }
                         ],
                         "additionalItems": {

--- a/lib/sb3_schema.json
+++ b/lib/sb3_schema.json
@@ -79,7 +79,7 @@
                 },
                 "md5ext": {
                     "type": "string",
-                    "pattern": "^[a-fA-F0-9]{32}.[a-zA-Z]+$"
+                    "pattern": "^[a-fA-F0-9]{32}.[a-zA-Z0-9]+$"
                 },
                 "name": {
                     "type": "string"

--- a/lib/sb3_schema.json
+++ b/lib/sb3_schema.json
@@ -296,8 +296,22 @@
                 "isStage": {
                     "type": "boolean",
                     "enum": [true]
+                },
+                "tempo": {
+                    "type": "number"
+                },
+                "videoTransparency": {
+                    "type": "number"
+                },
+                "videoState": {
+                    "type": "string",
+                    "enum": ["on", "off", "on-flipped"]
                 }
-            }
+            },
+            "required": [
+                "name",
+                "isStage"
+            ]
         },
         "sprite": {
             "type": "object",
@@ -371,10 +385,13 @@
                     "minItems": 1,
                     "uniqueItems": true
                 },
-                "sounds":{
+                "sounds": {
                     "type": "array",
                     "items": {"$ref":"#/definitions/sound"},
                     "uniqueItems": true
+                },
+                "volume": {
+                    "type": "number"
                 }
             },
             "required": [

--- a/lib/sb3_schema.json
+++ b/lib/sb3_schema.json
@@ -101,8 +101,8 @@
         "scalar_variable": {
             "type": "array",
             "items": [
-                {"type": "string"},
-                {"$ref":"#/definitions/scalarVal"}
+                {"type": "string", "description": "name of the variable"},
+                {"$ref":"#/definitions/scalarVal", "description": "value of the variable"}
             ],
             "additionalItems": {"type": "boolean", "enum": [true], "description": "Whether this is a cloud variable"},
             "maxItems": 3
@@ -110,18 +110,18 @@
         "list": {
             "type": "array",
             "items": [
-                {"type":"string"},
+                {"type":"string", "description": "name of the list"},
                 {
                     "type": "array",
+                    "description": "contents of the list",
                     "items": {"$ref":"#/definitions/scalarVal"}
                 }
             ],
             "additionalItems": false
         },
         "broadcast_message": {
-            "type": "array",
-            "items": {"type": "string"},
-            "additionalItems": false
+            "type": "string",
+            "description": "the message being broadcasted"
         },
         "num_primitive": {
             "type": "array",
@@ -371,13 +371,16 @@
                     }
                 },
                 "variables": {
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": {"$ref":"#/definitions/scalar_variable"}
                 },
                 "lists": {
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": {"$ref":"#/definitions/list"}
                 },
                 "broadcasts": {
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": {"$ref":"#/definitions/broadcast_message"}
                 },
                 "costumes": {
                     "type": "array",

--- a/lib/sb3_schema.json
+++ b/lib/sb3_schema.json
@@ -305,7 +305,7 @@
                 },
                 "videoState": {
                     "type": "string",
-                    "enum": ["on", "off", "on-flipped"]
+                    "enum": ["on", "off", "on_flipped"]
                 }
             },
             "required": [

--- a/lib/sb3_schema.json
+++ b/lib/sb3_schema.json
@@ -307,7 +307,7 @@
                 },
                 "videoState": {
                     "type": "string",
-                    "enum": ["on", "off", "on_flipped"]
+                    "enum": ["on", "off", "on-flipped"]
                 }
             },
             "required": [


### PR DESCRIPTION
Resolves #22 
Resolves LLK/scratch-vm#194

#### Proposed Changes
This pull request is one of the last major changes for the save/load work and should solidify the 3.0 format. Specifically, the changes made here cover the pre-compression work for the Scratch 3.0 format (related to LLK/scratch-vm#).

#### Related Pull Requests
This pull request is tied to the following others in scratch-vm and scratch-gui and should only be merged when all are ready since there are dependencies in both directions.

#### Testing
Testing has been done manually on importing 2.0 projects into 3.0 with 2 rounds of saving and loading. Actual fixtures to be added in the near future for the 3.0 format. Tracking this as an issue in #31.