### PR TITLE
refactor(sprite3_schema): clean up sprite3 representation

### DIFF
--- a/lib/sprite3_schema.json
+++ b/lib/sprite3_schema.json
@@ -3,40 +3,8 @@
     "$schema": "http://json-schema.org/schema#",
     "description": "Scratch 3.0 Sprite Schema",
     "type": "object",
-    "properties": {
-        "meta": {
-            "type": "object",
-            "properties": {
-                "semver": {
-                    "type": "string",
-                    "pattern": "^(3.[0-9]+.[0-9]+)$"
-                },
-                "vm": {
-                    "type": "string",
-                    "pattern": "^([0-9]+.[0-9]+.[0-9]+)($|-)"
-                },
-                "agent": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "semver"
-            ]
-        },
-        "targets": {
-            "type": "array",
-            "items": [
-                {
-                    "allOf": [
-                        {"$ref": "sb3_definitions.json#/definitions/sprite"},
-                        {"$ref": "sb3_definitions.json#/definitions/target"}
-                    ]
-                }
-            ],
-            "additionalItems": false
-        }
-    },
-    "required": [
-        "targets"
+    "allOf": [
+        {"$ref": "sb3_definitions.json#/definitions/sprite"},
+        {"$ref": "sb3_definitions.json#/definitions/target"}
     ]
 }


### PR DESCRIPTION
Minor change to sprite3 representation so that it is not nested inside an extra `{targets: ...}` since it should only ever represent one sprite.