### PR TITLE
fix(sb3_definitions): fix comment position validation

### DIFF
--- a/lib/sb3_definitions.json
+++ b/lib/sb3_definitions.json
@@ -9,6 +9,12 @@
                 {"type": "null"}
             ]
         },
+        "optionalNumber": {
+            "oneOf": [
+                {"type": "number"},
+                {"type": "null"}
+            ]
+        },
         "boolOrOptBoolString": {
             "oneOf": [
                 {"type": "string",
@@ -294,8 +300,8 @@
                     "maxLength": 8000
                 },
                 "minimized": {"type": "boolean"},
-                "x": {"type": "number"},
-                "y": {"type": "number"},
+                "x": {"$ref": "#/definitions/optionalNumber"},
+                "y": {"$ref": "#/definitions/optionalNumber"},
                 "width": {"type": "number"},
                 "height": {"type": "number"}
             },


### PR DESCRIPTION
A comment's x and y can be null. This will occur if a project is imported from 2.0, a sprite that is
not currently selected has comments, and that project is immediately saved in 3.0 without switching
to the other sprite that has comments.