### PR TITLE
Replace the async.waterfall in index with a Promise chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "ajv": "6.3.0",
-    "async": "2.6.0",
     "gzip-js": "0.3.2",
     "jszip": "3.1.5",
     "pify": "4.0.1"

--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
   "dependencies": {
     "ajv": "6.3.0",
     "async": "2.6.0",
+    "gzip-js": "0.3.2",
     "jszip": "3.1.5",
-    "gzip-js": "0.3.2"
+    "pify": "4.0.1"
   },
   "devDependencies": {
     "@commitlint/cli": "7.2.1",


### PR DESCRIPTION
- Update commitlint dependencies
  The commitmsg command was erroring and so not letting me commit changes.
- Replace async.waterfall with Promise chain
  scratch-parser is the only scratch package used by scratch-gui using the async module. We can save ~180KB of javascript by either using async-es, another similar package or promises. I didn't want to rewrite the commonjs modules into es modules so I opted for Promises.