### PR TITLE
feat(sb3_schema.json): add origin field to meta info

### DIFF
--- a/lib/sb3_schema.json
+++ b/lib/sb3_schema.json
@@ -17,6 +17,9 @@
                 },
                 "agent": {
                     "type": "string"
+                },
+                "origin": {
+                    "type": "string"
                 }
             },
             "required": [


### PR DESCRIPTION
Add a new field to the sb3 schema, an `origin` string in the meta info, representing an editor outside the scratch community where this project was created.

Part of https://github.com/LLK/scratch-vm/issues/2851